### PR TITLE
Add extra fields to DiscoveryConfig

### DIFF
--- a/core/src/main/scala/com/socrata/thirdparty/curator/DiscoveryConfig.scala
+++ b/core/src/main/scala/com/socrata/thirdparty/curator/DiscoveryConfig.scala
@@ -4,10 +4,12 @@ import com.socrata.thirdparty.typesafeconfig.ConfigClass
 import com.typesafe.config.Config
 
 /**
- * Contains service discovery config for use with Curator
+ * Contains service discovery/advertisement config for use with Curator
  * @param config Configuration object
  * @param root Root of the curator configuration subset
  */
 class DiscoveryConfig(config: Config, root: String) extends ConfigClass(config, root) {
   val serviceBasePath = getString("service-base-path")
+  val name = getString("name")
+  val address = getString("address")
 }


### PR DESCRIPTION
Really minor change - This lets us collapse the use of AdvertisementConfig from many services.
