### PR TITLE
Add some c3p0 utilities.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ val commonDeps = Seq(
   // Use older metrics-graphite to fix issue with reconnecting to graphite
   // See https://github.com/dropwizard/metrics/issues/694
   "com.codahale.metrics" % "metrics-graphite" % "3.0.2" exclude(
-                           "com.codahale.metrics", "metrics-core")
+                           "com.codahale.metrics", "metrics-core"),
+  "com.mchange"        % "c3p0"                % "0.9.5-pre9" % "optional"
 )
 
 val testDeps = Seq(

--- a/core/src/main/scala/com/socrata/thirdparty/c3p0/ConnectionCustomizer.scala
+++ b/core/src/main/scala/com/socrata/thirdparty/c3p0/ConnectionCustomizer.scala
@@ -1,0 +1,47 @@
+package com.socrata.thirdparty.c3p0
+
+import java.sql.Connection
+
+import com.mchange.v2.c3p0.AbstractConnectionCustomizer
+import com.mchange.v2.log.{MLevel, MLog, MLogger}
+import com.rojoma.simplearm.util.using
+
+/**
+ * Implementation of c3p0's AbstractConnectionCustomizer to let you execute arbitrary sql statements
+ * on any of the defined events.  The statements to execute are configured with key/value pairs in
+ * the c3p0 extensions configuration, named after each of the methods.  eg. "onAcquire".
+ */
+class ConnectionCustomizer extends AbstractConnectionCustomizer {
+  private val logger: MLogger = MLog.getLogger(classOf[ConnectionCustomizer])
+
+  private def getConfig(parentDataSourceIdentityToken: String, configName: String): Option[String] = {
+    return Option(extensionsForToken(parentDataSourceIdentityToken).get(configName).asInstanceOf[String])
+  }
+
+  private def onEvent(c: Connection, parentDataSourceIdentityToken: String, event: String) {
+    val sql = getConfig(parentDataSourceIdentityToken, event)
+    sql.foreach { s =>
+      using(c.createStatement()) { stmt =>
+        val result = stmt.executeUpdate(s)
+        if (logger.isLoggable(MLevel.FINEST)) logger.log(MLevel.FINEST, s"Executed $event statement $s on connection $c returned $result")
+      }
+    }
+  }
+
+  override def onAcquire(c: Connection, parentDataSourceIdentityToken: String) {
+    onEvent(c, parentDataSourceIdentityToken, "onAcquire")
+  }
+
+  override def onDestroy(c: Connection, parentDataSourceIdentityToken: String) {
+    onEvent(c, parentDataSourceIdentityToken, "onDestroy")
+  }
+
+  override def onCheckOut(c: Connection, parentDataSourceIdentityToken: String) {
+    onEvent(c, parentDataSourceIdentityToken, "onCheckOut")
+  }
+
+  override def onCheckIn(c: Connection, parentDataSourceIdentityToken: String) {
+    onEvent(c, parentDataSourceIdentityToken, "onCheckIn")
+  }
+
+}

--- a/core/src/main/scala/com/socrata/thirdparty/typesafeconfig/C3P0Propertizer.scala
+++ b/core/src/main/scala/com/socrata/thirdparty/typesafeconfig/C3P0Propertizer.scala
@@ -1,0 +1,34 @@
+package com.socrata.thirdparty.typesafeconfig
+
+import java.util.Properties
+
+import scala.collection.JavaConverters._
+
+import com.typesafe.config.{ConfigValueType, Config}
+
+
+/**
+ * Converts a Config object into a Properties object suitable for consumption
+ * by c3p0.  In particular, converts nested structures such as an "extensions"
+ * hash into an actual java.util.Map.  This violates the String => String
+ * contract of java.util.Properties, but is what c3p0 needs so that is what we will
+ * give it.
+ */
+object C3P0Propertizer extends ((String, Config) => Properties) {
+
+  def apply(root: String, config: Config): Properties = {
+    val props = new Properties()
+    val es = config.root().entrySet().asScala
+
+    es.foreach { entry =>
+      val newKey = if (root == "") entry.getKey else root + "." + entry.getKey
+      entry.getValue.valueType match {
+        case ConfigValueType.OBJECT | ConfigValueType.LIST => props.put(newKey, entry.getValue.unwrapped())
+        case ConfigValueType.NULL =>  // noop
+        case _ => props.setProperty(newKey, config.getString(entry.getKey))
+      }
+    }
+
+    props
+  }
+}

--- a/core/src/test/scala/com/socrata/thirdparty/typesafeconfig/C3P0PropertizerTest.scala
+++ b/core/src/test/scala/com/socrata/thirdparty/typesafeconfig/C3P0PropertizerTest.scala
@@ -1,0 +1,49 @@
+package com.socrata.thirdparty.typesafeconfig
+
+import scala.collection.JavaConverters._
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+import org.scalatest.matchers.MustMatchers
+
+import java.util.Properties
+
+class C3P0PropertizerTest extends FunSuite with MustMatchers {
+  val c3p0Config = ConfigFactory.parseString(
+    """c3p0 = {
+        maxPoolSize = 20
+        testConnectionOnCheckin = true
+        connectionCustomizerClassName=com.mchange.v2.c3p0.example.InitSqlConnectionCustomizer
+        extensions {
+          initSql="SET work_mem = '768MB'"
+          monkey="Marmoset"
+        }
+      }""")
+
+  val c3p0Props = new Properties
+  c3p0Props.setProperty("maxPoolSize", "20")
+  c3p0Props.setProperty("testConnectionOnCheckin", "true")
+  c3p0Props.setProperty("connectionCustomizerClassName", "com.mchange.v2.c3p0.example.InitSqlConnectionCustomizer")
+
+  val extensionsHash = new java.util.HashMap[String, String]()
+  extensionsHash.put("initSql", "SET work_mem = '768MB'")
+  extensionsHash.put("monkey", "Marmoset")
+
+  c3p0Props.put("extensions", extensionsHash)
+
+  test("Without being given a root") {
+    val props = C3P0Propertizer("", c3p0Config.getConfig("c3p0"))
+    props must equal (c3p0Props)
+  }
+
+  test("With a new root") {
+    val props = C3P0Propertizer("foo", c3p0Config.getConfig("c3p0"))
+    val targetProps = new Properties
+    for((k,v) <- c3p0Props.asInstanceOf[java.util.Map[String,Object]].asScala) {
+      targetProps.put("foo." + k, v)
+    }
+    props must equal (targetProps)
+  }
+
+
+}


### PR DESCRIPTION
- C3P0Propertizer which knows how to turn c3p0 Config into a Properties object that c3p0 will grok.
  Unfortunately this involves sticking a Map into the value of the Property, specifically for the
  "extensions" configuration: http://www.mchange.com/projects/c3p0/#extensions
- ConnectionCustomizer that can be used to run SQL at any of the four stages of connection lifecycle
  that c3p0 exposes.  Beyond me why this isn't already part of c3p0 itself.

This is then going to be used to set postgres parameters such as work_mem on connection acquire.
