### PR TITLE
Ae dev

### DIFF
--- a/core/src/main/scala/com/socrata/thirdparty/geojson/GeoJson.scala
+++ b/core/src/main/scala/com/socrata/thirdparty/geojson/GeoJson.scala
@@ -1,8 +1,8 @@
 package com.socrata.thirdparty.geojson
 
-import com.rojoma.json.ast._
-import com.rojoma.json.codec.JsonCodec
-import com.rojoma.json.util._
+import com.rojoma.json.v3.ast._
+import com.rojoma.json.v3.codec._
+import com.rojoma.json.v3.util._
 import com.vividsolutions.jts.geom._
 
 sealed trait GeoJsonBase

--- a/core/src/test/scala/com/socrata/thirdparty/geojson/GeoJsonTest.scala
+++ b/core/src/test/scala/com/socrata/thirdparty/geojson/GeoJsonTest.scala
@@ -1,8 +1,10 @@
 package com.socrata.thirdparty.geojson
 
-import com.rojoma.json.ast._
-import com.rojoma.json.io.JsonReader
+import com.rojoma.json.v3.ast._
+import com.rojoma.json.v3.io.JsonReader
 import com.vividsolutions.jts.geom._
+import com.vividsolutions.jts.geom.impl.CoordinateArraySequence
+import org.scalacheck.{Gen, Arbitrary}
 import org.scalatest.{Matchers, FunSpec}
 
 
@@ -15,6 +17,64 @@ trait GeoTest {
   def polygon(coords: (Double, Double)*) = factory.createPolygon(ring(coords), Array.empty)
   def polygon(outer: Seq[(Double, Double)], inner: Seq[Seq[(Double, Double)]] = Seq.empty) =
     factory.createPolygon(ring(outer), inner.map(ring).toArray)
+
+
+  // generate arbitrary coordinate
+  implicit val arbCoordinate = Arbitrary[Coordinate]{
+    for {
+    // limits are +/- 180, avoid having to deal with adding constraints on tests.
+      lon <- Gen.choose(-170d, 170d)
+      // limits are +/- 90, avoid having to deal with adding constraints on tests.
+      lat <- Gen.choose(-80d, 80d)
+    } yield coord(lon, lat)
+  }
+
+  // Set up for arbitrary point, to be used to test round trip encode -> decode
+  implicit val arbPoint = Arbitrary[Point] {
+    for {
+      c <- Arbitrary.arbitrary[Coordinate]
+    } yield new Point(new CoordinateArraySequence(Array(c)), factory)
+  }
+
+  implicit val arbPoly = Arbitrary[Polygon] {
+    def mkRing(lon: Double, lat: Double, size: Double) = {
+      ring(Seq((lon, lat),(lon+size, lat),(lon+size, lat+size),(lon, lat+size),(lon, lat)))
+    }
+
+    for {
+      c <- Arbitrary.arbitrary[Coordinate]
+
+      shell = mkRing(c.x, c.y, 1)
+      holes = Array(mkRing(c.x + 0.1, c.y + 0.1, 0.1), mkRing(c.x + .3, c.y + .3, 0.2))
+    } yield new Polygon(shell, holes, factory)
+  }
+
+
+  implicit val arbMultiLineStr = Arbitrary[MultiLineString] {
+    for{
+      c1 <- Arbitrary.arbitrary[Coordinate]
+      c2 <- Arbitrary.arbitrary[Coordinate]
+      c3 <- Arbitrary.arbitrary[Coordinate]
+      c4 <- Arbitrary.arbitrary[Coordinate]
+
+      ls1 = linestring((c1.x, c1.y), (c2.x, c2.y))
+      ls2 = linestring((c3.x, c3.y), (c4.x, c4.y))
+    } yield factory.createMultiLineString(Array(ls1,ls2))
+  }
+
+  implicit val arbMultiPoly = Arbitrary[MultiPolygon] {
+    for{
+      p <- Arbitrary.arbitrary[Polygon]
+      p1 <- Arbitrary.arbitrary[Polygon]
+      p2 <- Arbitrary.arbitrary[Polygon]
+      p3 <- Arbitrary.arbitrary[Polygon]
+
+    } yield factory.createMultiPolygon(Array(p, p1, p2, p3))
+
+  }
+
+
+
 }
 
 class GeoJsonTest extends FunSpec with Matchers with GeoTest {
@@ -32,7 +92,7 @@ class GeoJsonTest extends FunSpec with Matchers with GeoTest {
 
   describe("FeatureJson") {
     it("should decode a Feature GeoJSON") {
-      GeoJson.codec.decode(JsonReader.fromString(feat)) should equal (Some(featureJson))
+      GeoJson.codec.decode(JsonReader.fromString(feat)) should equal (Right(featureJson))
     }
   }
 
@@ -41,7 +101,7 @@ class GeoJsonTest extends FunSpec with Matchers with GeoTest {
       val body = """{"type":"FeatureCollection",
                     |"crs": {"type": "name", "properties": {"foo": "gooblygoo"}},
                     |"features": [""".stripMargin + feat + "]}"
-      GeoJson.codec.decode(JsonReader.fromString(body)) should equal (Some(
+      GeoJson.codec.decode(JsonReader.fromString(body)) should equal (Right(
         FeatureCollectionJson(features = Seq(featureJson),
                               crs = Some(CRS("name", Map("foo" -> JString("gooblygoo")))) )))
     }

--- a/core/src/test/scala/com/socrata/thirdparty/geojson/JtsCodecsTest.scala
+++ b/core/src/test/scala/com/socrata/thirdparty/geojson/JtsCodecsTest.scala
@@ -1,13 +1,14 @@
 package com.socrata.thirdparty.geojson
 
-import com.rojoma.json.ast._
-import com.rojoma.json.io.JsonReader
+import com.rojoma.json.v3.ast._
+import com.rojoma.json.v3.codec.JsonDecode
+import com.rojoma.json.v3.io.JsonReader
 import com.vividsolutions.jts.geom._
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FunSpec, Matchers}
 
-
-class JtsCodecsTest extends FunSpec with Matchers with GeoTest {
-  import JtsCodecs._
+class JtsCodecsTest extends FunSpec with Matchers with PropertyChecks with GeoTest {
+  import com.socrata.thirdparty.geojson.JtsCodecs._
 
   val pointCoords = JArray(Seq(JNumber(6.0), JNumber(1.2)))
   val point2Coords = JArray(Seq(JNumber(3.4), JNumber(-2.7)))
@@ -22,9 +23,13 @@ class JtsCodecsTest extends FunSpec with Matchers with GeoTest {
                     |  "type": "Point",
                     |  "coordinates": [6.0, 1.2]
                     |}""".stripMargin
-      val pt = decodeString(body).asInstanceOf[Option[Point]]
-      (pt.get.getX, pt.get.getY) should equal (6.0, 1.2)
-      encode(pt.get) should be (JsonReader.fromString(body))
+      val pt = decodeString(body).asInstanceOf[JsonDecode.DecodeResult[Point]].right.get
+      (pt.getX, pt.getY) should equal (6.0, 1.2)
+
+      // uses implicit arbitrary.
+      forAll { (point: Point) =>
+        geoCodec.decode(encode(point)) should equal (Right(point))
+      }
     }
 
     it("should convert geometry JSON of type Polygon - exterior and interior ring(s)") {
@@ -33,10 +38,15 @@ class JtsCodecsTest extends FunSpec with Matchers with GeoTest {
                     |  "coordinates": [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
                     |                  [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
                     |}""".stripMargin
-      val p = decodeString(body).asInstanceOf[Option[Polygon]]
-      p.get should equal (polygon(Seq((100.0, 0.0), (101.0, 0.0), (101.0, 1.0), (100.0, 1.0), (100.0, 0.0)),
+      val p = decodeString(body).asInstanceOf[JsonDecode.DecodeResult[Polygon]].right.get
+      p should equal (polygon(Seq((100.0, 0.0), (101.0, 0.0), (101.0, 1.0), (100.0, 1.0), (100.0, 0.0)),
                                   Seq(Seq((100.2, 0.2), (100.8, 0.2), (100.8, 0.8), (100.2, 0.8), (100.2, 0.2)))))
-      encode(p.get) should be (JsonReader.fromString(body))
+
+      forAll{(poly: Polygon) =>
+        geoCodec.decode(encode(poly)) should equal (Right(poly))
+      }
+
+
     }
 
     it("should convert geometry JSON of type Polygon - exterior ring only") {
@@ -44,9 +54,14 @@ class JtsCodecsTest extends FunSpec with Matchers with GeoTest {
                    |  "type": "Polygon",
                    |  "coordinates": [[[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.0, 0.0]]]
                    |}""".stripMargin
-      val p = decodeString(body).asInstanceOf[Option[Polygon]]
-      p.get should equal (polygon((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (0.0, 0.0)))
-      encode(p.get) should be (JsonReader.fromString(body))
+      val p = decodeString(body).asInstanceOf[JsonDecode.DecodeResult[Polygon]].right.get
+      p should equal (polygon((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (0.0, 0.0)))
+
+      forAll { (c: Coordinate, c1: Coordinate, c2: Coordinate, c3: Coordinate) =>
+        val extPolygon = polygon((c.x, c.y), (c1.x, c1.y), (c2.x, c2.y), (c.x, c.y))
+
+        geoCodec.decode(encode(extPolygon)) should equal (Right(extPolygon))
+      }
     }
 
     it("should convert geometry JSON of MultiLineString") {
@@ -57,8 +72,11 @@ class JtsCodecsTest extends FunSpec with Matchers with GeoTest {
       val mls = factory.createMultiLineString(Array(
                   linestring((0.0, 0.0), (0.0, 1.0)), linestring((1.0, 0.0), (1.0, 1.0))
                 ))
-      decodeString(body) should equal (Some(mls))
-      encode(mls) should be (JsonReader.fromString(body))
+      decodeString(body).right.get should equal (mls)
+
+      forAll{(ml: MultiLineString) =>
+        geoCodec.decode(encode(ml)) should equal (Right(ml))
+      }
     }
 
     it("should convert geometry JSON of type MultiPolygon") {
@@ -70,28 +88,32 @@ class JtsCodecsTest extends FunSpec with Matchers with GeoTest {
                  polygon((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (0.0, 0.0)),
                  polygon((1.0, 1.0), (1.0, 2.0), (2.0, 2.0), (1.0, 1.0))
                ))
-      decodeString(body) should equal (Some(mp))
-      encode(mp) should be (JsonReader.fromString(body))
+      decodeString(body) should be (Right(mp))
+
+      forAll{(mp: MultiPolygon) =>
+        geoCodec.decode(encode(mp)) should equal (Right(mp))
+      }
+
     }
 
     it("should not convert non-GeoJSON or unsupported types") {
       val body = JObject(Map("type" -> JString("foo"), "coordinates" -> pointCoords))
-      geoCodec.decode(body) should equal (None)
+      geoCodec.decode(body) should be ('left)
 
       val body2 = JArray(Seq(JString("totally not"), JNumber(5.6)))
-      geoCodec.decode(body2) should equal (None)
+      geoCodec.decode(body2) should be ('left)
     }
   }
 
   describe("coordinates") {
     it("should convert Points correctly") {
-      val pt = PointCodec.decode(pointCoords)
-      (pt.get.getX, pt.get.getY) should equal (6.0, 1.2)
+      val pt = PointCodec.decode(pointCoords).right.get
+      (pt.getX, pt.getY) should equal (6.0, 1.2)
     }
 
     it("should not convert non-Points") {
-      PointCodec.decode(JArray(Seq(JNumber(-1)))) should equal (None)
-      PointCodec.decode(lineCoords) should equal (None)
+      PointCodec.decode(JArray(Seq(JNumber(-1)))) should be ('left)
+      PointCodec.decode(lineCoords) should be ('left)
     }
   }
 }

--- a/test/src/main/scala/com/socrata/thirdparty/curator/CuratorServiceIntegration.scala
+++ b/test/src/main/scala/com/socrata/thirdparty/curator/CuratorServiceIntegration.scala
@@ -53,10 +53,11 @@ trait CuratorServiceIntegration {
   lazy val curator = CuratorFromConfig.unmanaged(curatorConfig)
   lazy val discovery = DiscoveryFromConfig.unmanaged(classOf[AuxiliaryData], curator, discoveryConfig)
 
-  lazy val httpClient = new HttpClientHttpClient(Executors.newCachedThreadPool(),
-                                                 HttpClientHttpClient.
-                                                   defaultOptions.
-                                                   withUserAgent("test"))
+  // HttpClientHttpClient constructor has changed, as such  .Options object needs to be passed.
+  private lazy val httpOptions: HttpClientHttpClient.Options = HttpClientHttpClient.defaultOptions
+  httpOptions.withUserAgent("test")
+  httpOptions.withLivenessChecker(NoopLivenessChecker)
+  lazy val httpClient = new HttpClientHttpClient( Executors.newCachedThreadPool(), httpOptions)
 
   protected def getFallback = ConfigFactory.load()
 


### PR DESCRIPTION
Fixed an issue with CuratorServiceIntegration trait that was causing Geospace tests to fail because class was calling for a constructor for HttpClientHttpClient that has previously been changed. In addition, I have updated geojson package to use rojoma-json-v3 as we bump up geospace and other geotools to this version of json tools. 